### PR TITLE
chore: update @currents/cmd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@currents/cmd": "^1.3.1",
+        "@currents/cmd": "^1.4.0",
         "@wdio/cli": "^9.2.14",
         "newman": "^6.2.1",
         "xml2js": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@currents/cmd": "^1.3.1",
+    "@currents/cmd": "^1.4.0",
     "@wdio/cli": "^9.2.14",
     "newman": "^6.2.1",
     "xml2js": "^0.6.2"


### PR DESCRIPTION
There is no `@currents/cmd: v1.3.1` :)

![image](https://github.com/user-attachments/assets/f344089c-6166-4510-9e38-816f550f296e)

https://www.npmjs.com/package/@currents/cmd?activeTab=versions